### PR TITLE
Fix generator prompts

### DIFF
--- a/_templates/component/new/prompt.js
+++ b/_templates/component/new/prompt.js
@@ -1,20 +1,20 @@
 module.exports = [
   {
-    type: "input",
-    name: "name",
     message: "What's the name of the component?",
+    name: "name",
+    type: "input",
   },
   {
-    type: "list",
-    name: "componentType",
-    message: "What kind?",
     choices: ["function", "class"],
     default: "function",
+    message: "What kind?",
+    name: "componentType",
+    type: "select",
   },
   {
-    type: "confirm",
-    name: "connected",
-    message: "Is the component connected to Redux?",
     default: "N",
+    message: "Is the component connected to Redux?",
+    name: "connected",
+    type: "toggle",
   },
 ];

--- a/_templates/util/new/prompt.js
+++ b/_templates/util/new/prompt.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
-    type: "input",
-    name: "name",
     message: "What's the name of the utility?",
+    name: "name",
+    type: "input",
   },
 ];


### PR DESCRIPTION
## Overview

Changes type from `list` to `select` in `prompt.js`

## Review Checklist

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards

## Testing Instructions

1. Run `npm run new:component` and ensure that options are presented and selectable
