### PR TITLE
Update component generator to use hooks

### DIFF
--- a/_templates/component/new/index.ejs.t
+++ b/_templates/component/new/index.ejs.t
@@ -2,30 +2,30 @@
 to: src/components/<%= name %>/index.tsx
 ---
 <% const nameBase = connected ? name + "Base" : name -%>
-<% if(componentType === "class") { -%>
-import React, { Component } from "react"
+<% if(useState) { -%>
+import React, { useState } from "react"
 <% if(connected) { -%>
 import { connect } from "react-redux"
-import { ReduxMapStateToProps } from "../../types/ReduxMapStateToProps"
+import { MapStateToProps } from "../../types/MapStateToProps"
 <% } -%>
 
-interface Props {}
-interface State {}
+type Props = Readonly<{ children?: React.ReactNode }>
 
-export class <%= nameBase %> extends Component<Props, State> {
-  public static displayName = "<%= name %>"
-  public static defaultProps = {}
-  public state = {}
-  public render() {
-    const { children } = this.props
-    return <div className="<%= name %>">{children}</div>
-  }
+export function <%= nameBase %>({ children }: Props) {
+  const [count, setCount] = useState(0)
+  return (
+    <div className="<%= name %>">
+      <p>You clicked {count} times</p>
+      <button onClick={() => setCount(count + 1)}>Click me</button>
+      {children}
+    </div>
+  )
 }
 <% } else { -%>
 import React from "react"
 <% if(connected) { -%>
 import { connect } from "react-redux"
-import { ReduxMapStateToProps } from "../../types/ReduxMapStateToProps"
+import { MapStateToProps } from "../../types/MapStateToProps"
 <% } -%>
 
 type Props = Readonly<{ children?: React.ReactNode }>
@@ -38,10 +38,7 @@ export function <%= nameBase %>({ children }: Props) {
 
 interface PropsOuter {}
 
-const mapStateToProps: ReduxMapStateToProps<
-  Props,
-  PropsOuter
-> = (/* state, propsOuter */) => {
+const mapStateToProps: MapStateToProps<Props, PropsOuter> = (/* state, propsOuter */) => {
   return {}
 }
 

--- a/_templates/component/new/prompt.js
+++ b/_templates/component/new/prompt.js
@@ -1,20 +1,19 @@
 module.exports = [
   {
-    type: "input",
+    message: "Component name:",
     name: "name",
-    message: "What's the name of the component?",
+    type: "input",
   },
   {
-    type: "list",
-    name: "componentType",
-    message: "What kind?",
-    choices: ["function", "class"],
-    default: "function",
-  },
-  {
-    type: "confirm",
-    name: "connected",
-    message: "Is the component connected to Redux?",
     default: "N",
+    message: "Does component use state?",
+    name: "useState",
+    type: "toggle",
+  },
+  {
+    default: "N",
+    message: "Is component connected to redux?",
+    name: "connected",
+    type: "toggle",
   },
 ];

--- a/_templates/component/new/stories.ejs.t
+++ b/_templates/component/new/stories.ejs.t
@@ -4,6 +4,9 @@ to: src/components/<%= name %>/stories.tsx
 <% const nameBase = connected ? name + "Base" : name -%>
 import { storiesOf } from "@storybook/react"
 import React from "react"
+import { decoratorCentered } from "../../utils/decoratorCentered"
 import { <%= connected ? `${nameBase} as ${name}` : name %> } from "."
 
-storiesOf("<%= name %>", module).add("default", () => <<%= name %>><%= name %></<%= name %>>)
+storiesOf("<%= name %>", module)
+  .addDecorator(decoratorCentered)
+  .add("default", () => <<%= name %>><%= name %></<%= name %>>)

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -8,7 +8,13 @@ import { shallowRender } from "../../utils/shallowRender"
 
 describe("<%= name %>", () => {
   it("renders", () => {
-    const received = shallowRender(<<%= name %>><%= name %></<%= name %>>)
+    // Arrange
+    const valA = <%= name %>
+
+    // Act
+    const received = shallowRender(<<%= name %>>{valA}</<%= name %>>)
+
+    // Assert
     expect(received).toMatchSnapshot()
   })
 })

--- a/_templates/util/new/index.ejs.t
+++ b/_templates/util/new/index.ejs.t
@@ -1,6 +1,9 @@
 ---
 to: src/utils/<%= name %>/index.ts
 ---
-export const <%= name %> = () => {
-  return undefined
-}
+<%_ var nameCap = h.inflection.camelize(name, false);_%>
+// Define
+type <%= nameCap %> = <A>(a: A) => A
+
+// Implement
+export const <%= name %>: <%= nameCap %> = x => x

--- a/_templates/util/new/prompt.js
+++ b/_templates/util/new/prompt.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
-    type: "input",
-    name: "name",
     message: "What's the name of the utility?",
+    name: "name",
+    type: "input",
   },
 ];

--- a/_templates/util/new/test.ejs.t
+++ b/_templates/util/new/test.ejs.t
@@ -2,9 +2,16 @@
 to: src/utils/<%= name %>/test.ts
 ---
 import { <%= name %> } from "."
+
 describe("<%= name %>", () => {
-  it("returns undefined", () => {
-    const received = <%= name %>()
-    expect(received).toBe(undefined)
+  it("works", () => {
+    // Arrange
+    const valA = 1
+
+    // Act
+    const received = <%= name %>(valA)
+
+    // Assert
+    expect(received).toEqual(1)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3498,9 +3498,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
-      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.9.tgz",
+      "integrity": "sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ==",
       "dev": true
     },
     "@types/q": {
@@ -3510,9 +3510,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.1.tgz",
-      "integrity": "sha512-tD1ETKJcuhANOejRc/p7OgQ16DKnbGi0M3LccelKlPnUCDp2a5koVxZFoRN9HN+A+m84HB5VGN7I+r3nNhS3PA==",
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.3.tgz",
+      "integrity": "sha512-PjPocAxL9SNLjYMP4dfOShW/rj9FDBJGu3JFRt0zEYf77xfihB6fq8zfDpMrV6s82KnAi7F1OEe5OsQX25Ybdw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3520,18 +3520,28 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.11.tgz",
-      "integrity": "sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.2.tgz",
+      "integrity": "sha512-MX7n1wq3G/De15RGAAqnmidzhr2Y9O/ClxPxyqaNg96pGyeXUYPSvujgzEVpLo9oIP4Wn1UETl+rxTN02KEpBw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
       }
     },
+    "@types/react-redux": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.0.1.tgz",
+      "integrity": "sha512-+DIH7TI2MT4Ke4lOrRMgNy//DzTDIzv5QwkJSD6AVrlsIgzf7yMM0JoWL5wJUXYwKQ2f1FgvwlvIVGD2QWQnew==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      }
+    },
     "@types/react-test-renderer": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.0.3.tgz",
-      "integrity": "sha512-NWOAxVQeJxpXuNKgw83Hah0nquiw1nUexM9qY/Hk3a+XhZwgMtaa6GLA9E1TKMT75Odb3/KE/jiBO4enTuEJjQ==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.8.1.tgz",
+      "integrity": "sha512-8gU69ELfJGxzVWVYj4MTtuHxz9nO+d175XeQ1XrXXxesUBsB4KK6OCfzVhEX6leZWWBDVtMJXp/rUjhClzL7gw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -13244,7 +13254,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -21551,14 +21560,25 @@
       }
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
+          "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-app-polyfill": {
@@ -21722,14 +21742,25 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
+      "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
+          "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-error-overlay": {
@@ -21764,8 +21795,7 @@
     "react-is": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
-      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
-      "dev": true
+      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -21783,6 +21813,42 @@
         "prop-types": "^15.5.10",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^3.0.0"
+      }
+    },
+    "react-redux": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.0.tgz",
+      "integrity": "sha512-EmbC3uLl60pw2VqSSkj6HpZ6jTk12RMrwXMBdYtM6niq0MdEaRq9KYCwpJflkOZj349BLGQm1MI/JO1W96kLWQ==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "react-scripts": {
@@ -21864,15 +21930,23 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
-      "integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.2.tgz",
+      "integrity": "sha512-gsd4NoOaYrZD2R8zi+CBV9wTGMsGhE2bRe4wvenGy0WcLJgdPscRZDDz+kmLjY+/5XpYC8yRR/v4CScgYfGyoQ==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "scheduler": "^0.12.0"
+        "react-is": "^16.8.2",
+        "scheduler": "^0.13.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
+          "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==",
+          "dev": true
+        }
       }
     },
     "react-textarea-autosize": {
@@ -23266,9 +23340,10 @@
       }
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
+      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2",
+    "react-redux": "^6.0.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^4.1.11",
@@ -14,9 +15,10 @@
     "@storybook/react": "^4.1.11",
     "@types/jest": "^24.0.0",
     "@types/node": "10.12.21",
-    "@types/react": "16.8.1",
-    "@types/react-dom": "16.0.11",
-    "@types/react-test-renderer": "^16.0.3",
+    "@types/react": "^16.8.3",
+    "@types/react-dom": "^16.8.2",
+    "@types/react-redux": "^7.0.1",
+    "@types/react-test-renderer": "^16.8.1",
     "@types/storybook__addon-actions": "^3.4.1",
     "@types/storybook__react": "^4.0.0",
     "cypress": "^3.1.5",
@@ -26,7 +28,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.16.4",
     "react-scripts": "2.1.3",
-    "react-test-renderer": "^16.7.0",
+    "react-test-renderer": "^16.8.2",
     "serve": "^10.1.2",
     "source-map-explorer": "^1.6.0",
     "start-server-and-test": "^1.7.11",

--- a/src/types/MapStateToProps.ts
+++ b/src/types/MapStateToProps.ts
@@ -1,0 +1,6 @@
+import { State } from "./State"
+
+export type MapStateToProps<Props, PropsOuter = {}> = (
+  state: State,
+  propsOuter: PropsOuter
+) => Props

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -1,0 +1,1 @@
+export interface State {} // tslint:disable-line

--- a/src/utils/decoratorCentered/__snapshots__/test.tsx.snap
+++ b/src/utils/decoratorCentered/__snapshots__/test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decoratorCentered works 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "padding": "1em",
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div>
+    test
+  </div>
+</div>
+`;

--- a/src/utils/decoratorCentered/index.tsx
+++ b/src/utils/decoratorCentered/index.tsx
@@ -1,0 +1,20 @@
+import { StoryDecorator } from "@storybook/react"
+import React from "react"
+
+export const decoratorCentered: StoryDecorator = story => (
+  <div
+    style={{
+      padding: "1em",
+      position: "absolute",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    }}
+  >
+    {story()}
+  </div>
+)

--- a/src/utils/decoratorCentered/readme.md
+++ b/src/utils/decoratorCentered/readme.md
@@ -1,0 +1,5 @@
+# decoratorCentered
+
+## Overview
+
+A storybook decorator used bay all generated component stories. It centers the rendered component in the view. If this isn't the desired effect, simply remove it.

--- a/src/utils/decoratorCentered/test.tsx
+++ b/src/utils/decoratorCentered/test.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { decoratorCentered } from "."
+
+describe("decoratorCentered", () => {
+  it("works", () => {
+    // Arrange
+    const story = () => <div>test</div>
+    const context = { kind: "kind", story: "test" }
+
+    // Act
+    const received = decoratorCentered(story, context)
+
+    // Assert
+    expect(received).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## Overview

 Changes the "Component type" question that used to let you generate a class or function to a prompt that asked if the component "uses state", generating a simple counter component if the answer is "yes".

Also:
- Adds `MapStateToProps` interface and corresponding `State` interface for connected component
- Tests now follow the Arrange, Act, Assert pattern.

## Review Checklist

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards

## Testing Instructions

1. `npm run new:component` prompts the user with "Does component use state?"