### PR TITLE
Correct the new:util script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run the following scripts with `npm run <SCRIPT_HERE>`:
 
 - `start` - start app
 - `new:component` - generate a new component
-- `new:utility` - generate a new util(ity)
+- `new:util` - generate a new util(ity)
 - `test:analyze` - run bundle analyzer
 - `test:e2e` - run end-to-end tests
 - `test:lint:fix` - run linter and fix if possible


### PR DESCRIPTION
## Description

Executing `new:utility` fails and suggests that you might have meant to
call `new:util`.

This changes the `README` to refer to the command as `new:util` instead.

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup
