### PR TITLE
CAW-37: Fix eslint config issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,6 @@
       "src/**/*.{ts,tsx}"
     ]
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "loki": {
     "requireReference": true,
     "configurations": {


### PR DESCRIPTION
## Description for #37

I discovered that this is causing a conflict with the extends defined in `.eslintrc.js`:

```json
// package.json

"eslintConfig": {
  "extends": "react-app"
},
```

The fix seems to be to remove it from `package.json`.

### 📋 Acceptance Criteria

> Checked off by the PR **Assignee(s)**

- [x] There are no longer any weird conflicts between CRA and local ESLint config


### 👩‍🔬 Test Instructions

1. run `npm ci`
1. Reload VSCode
1. Change prettier settings to something noticeably different (trailingComas)
1. run `npm start` and ensure that the expected lint errors are shown in terminal
1. Reload VSCode and ensure that they the expected errors are highlighted in the editor

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup
