### PR TITLE
Fix not-to-component-implementation RegExp

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -12,7 +12,7 @@ module.exports = {
         path: "^src/[^/]+/([^/]+)/.+"
       },
       to: {
-        path: "^src/components/[^/]+/[^index.tsx?]",
+        path: "^src/components/[^/]+/(?!index.tsx?)",
         pathNot: "^src/components/$1/.+"
       }
     },


### PR DESCRIPTION
## Description for [CAW-10](https://crema.atlassian.net/browse/CAW-10)

Fixes the regular expression that handles component privacy. It was using a negated set, where it should have been using a negative lookahead. The negated set allowed files other than `index.ts(x)` to be imported from, against the intentions of this rule.

### 👩‍🔬 Test Instructions

1. Inside a component directory, add a file starting with "i", "n", "d", "e", ...
2. Import that file from another component
3. `npm run test:deps`
4. Expect to see a `not-to-component-implementation` error (previously, would have been allowed)

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

### Additional

> Delete if unneeded

- [ ] Code has been tested and confirmed locally

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup
