### PR TITLE
CAW-187: Fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js -linguist-detectable
+*.ejs.t -linguist-detectable


### PR DESCRIPTION
## Description

Attempts to exclude `*.js` and `*.ejs.t` files from language stats since this does not reflect the primary language of the codebase. Certain tools only use `js` configs but this doesn't need to be highlighted as a primary language. This is attempted by utilizing the `.gitattributes` file that is read by `linguist`. This is only generated on the default branch, so we'll need to merge it to even see if this works 🤷‍♂ 

Closes #187 

### 🖼 Demo Images

#### Current:

![Screen Shot 2020-03-05 at 17 48 49](https://user-images.githubusercontent.com/157195/76036431-affa9200-5f09-11ea-9224-8d042d514d53.png)

#### Updated:

TBD


### 📋 Acceptance Criteria

> Checked off by the PR **Assignee(s)**

- [ ] Typescript is primary language instead of JS

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup
