### PR TITLE
Fix broken test:unit:coverage:watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:types": "tsc",
     "test:unit": "npm run test --",
     "test:unit:coverage": "npm run test:unit -- --coverage --watchAll=false",
-    "test:unit:coverage:watch": "npm run test:unit:coverage -- --watch",
+    "test:unit:coverage:watch": "npm run test:unit:coverage -- --watchAll=true",
     "test:visual": "CI=true loki --port 9009 --chromeDockerImage=yukinying/chrome-headless-browser-xl:74.0.3729.28",
     "test:visual:ci:start": "CI=true loki --port 5000 --chromeDockerImage=yukinying/chrome-headless-browser-xl:74.0.3729.28",
     "test:visual:ci": "start-server-and-test test:playground:ci http://localhost:5000 test:visual:ci:start",


### PR DESCRIPTION
## Description

It was discovered that the `test:unit:coverage:watch` wasn't working as expected. This fixes that.

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [x] running `npm run test:unit:coverage:watch` script works as expected

### 🖼 Demo

![Screen Recording 2020-04-24 at 11 28 AM](https://user-images.githubusercontent.com/157195/80235362-38023b80-861f-11ea-98ca-f503011525de.gif)
<!-- If applicable, use "Before/After Table" located at end of file -->

### 👩‍🔬 Test Instructions

> _Provided by PR **Assignees**_

1. run `npm run test:unit:coverage:watch`
1. confirm that it works

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
