### PR TITLE
Update .prettierrc.js to fix windows line break bug.

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: false,
   tabWidth: 2,
   trailingComma: "all",
+  endOfLine: "lf",
 }


### PR DESCRIPTION
## Description

Forces Line Feed over Carriage Return for line breaks. This will help because windows doesn't recognize only CR as a new line and won't run the app.

### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [x] App runs on windows with minimal configuration beyond what is stated.

<!--
### 🖼 Demo

![](DEMO_IMAGE_LINK_HERE)
-->

<!-- If applicable, use "Before/After Table" located at end of file -->

### 👩‍🔬 Test Instructions

> _Provided by PR **Assignees**_

1. Grab a windows machine and pull this code down.
1. Run `npm run test:lint:fix` if you encounter CR error on windows.

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
