### PR TITLE
Add pull_request event to workflow triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   Test:


### PR DESCRIPTION
## Description

GitHub Actions were not being triggered when a PR from a fork was opened. This was caused by only having `push` as a trigger and was fixed by adding `pull_request` to the events list.

### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

- [GitHub Docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-list-of-events)

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [ ] PR triggers CI workflow

<!--
### 🖼 Demo

![](DEMO_IMAGE_LINK_HERE)
-->

<!-- If applicable, use "Before/After Table" located at end of file -->

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
