### PR TITLE
Add npmrc to use legacy-peer-deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Description

For now we'll need to use legacy-peer-deps because too many packages have too restrictive peerDependencies.


### 📋 Acceptance Criteria

> Checked off by the PR **Assignee(s)**

- [x] `npm i` works now


### 👩‍🔬 Test Instructions

1. `npm i` works
2. `npm run test:ci` works

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

### Additional

> Delete if unneeded

- [ ] Code has been tested and confirmed locally

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup