### PR TITLE
GH-758: Run checks on correct events

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+    types: [opened]
 
 jobs:
   TestTemplate:


### PR DESCRIPTION
## Description

Changes the GitHub Action CI workflow to run differently to avoid redundant checks.

```
on:
  push:
  pull_request:
    types: [opened]
```

I read this as:
"Run me on any push—and then only on the initial opening of a PR"


### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

closes #758 

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [ ] Only runs `push` on pushes
- [ ] Only runs `pull_request` when opened

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
