### PR TITLE
GH-763: Enhance dependency-cruiser private module rule

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -2,18 +2,19 @@ module.exports = {
   forbidden: [
     /* custom rules */
     {
-      name: 'not-to-component-implementation',
+      name: "not-to-private",
       severity: 'error',
-      comment: `This module depends on the implementation details of a component.
-        Consider changing the importer to instead depend only on what is exposed by the top-level component.
-        Given more scrutiny, you may also consider extracting the desired functionality to a new top-level component.
+      comment: `
+        This module is attempting to import something that is private to another module; 
+        something not explicitly exported by a module's "index.ts(x)" file.
+        This rule applies to all top-level directories within "./src".
       `,
       from: {
-        path: "^src/[^/]+/([^/]+)/.+"
+        path: "^src/([^/]+)/([^/]+)/?.+"
       },
       to: {
-        path: "^src/components/[^/]+/(?!index.tsx?)",
-        pathNot: "^src/components/$1/.+"
+        path: "^src/$1/[^/]+/(?!index.tsx?)",
+        pathNot: "^src/$1/$2/.+"
       }
     },
 


### PR DESCRIPTION
## Description

Top-level directories within `./src/` will be enforced by this rule.
Utils, Types, and Components—in addition to any future src/* dirs:
```
▶ npx depcruise --validate -- src

  error not-to-private: src/utils/bar/bar.ts → src/utils/foo/foo.ts
  error not-to-private: src/types/Bar.ts → src/types/Baz/Priv.ts
  error not-to-private: src/components/Foo/Foo.tsx → src/components/Bar/Test/index.tsx

✖ 3 dependency violations (3 errors, 0 warnings). 38 modules, 35 dependencies cruised.
```

closes #763 

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [x] Files with the above import paths don't pass
- [x] Files with the below import paths do pass
  - [x] `src/utils/bar/bar.ts → src/utils/foo` ✅
  - [x] `src/types/Foo.ts → src/types/Bar.ts` ✅ 
  - [x] `src/components/Foo/Foo.tsx → src/components/Bar` ✅
  - [x] `src/components/Foo/Foo.tsx` can import any nested private module/file within its own directory
  - [x] `src/*/*/index.ts` can expose any private modules as public

<!--
### 🖼 Demo

![](DEMO_IMAGE_LINK_HERE)
-->

<!-- If applicable, use "Before/After Table" located at end of file -->

### 👩‍🔬 Test Instructions

> _Provided by PR **Assignees**_

1. `npm run new:(util|test|component)` to create modules that import from the main non-index path (or direct path in the case of types)

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
