### PR TITLE
Proposal: Remove CI from prepush and add lint-staged

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run prepush
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "new:component": "hygen component new",
     "new:type": "hygen type new",
     "new:util": "hygen util new",
-    "prepush": "npm run test:ci",
     "static": "serve -s build -p 5000",
     "deps:graph": "depcruise --validate --output-type dot -- src | dot -T svg > dependency-graph.svg",
     "deps:report": "depcruise --validate --output-type err-html --output-to dependency-report.html -- src",


### PR DESCRIPTION
## Description

Closes #1052 

>Is your feature request related to a problem? Please describe.
Running CI gets expensive (takes minutes) very quickly and enforcing it before pushing code to a branch discourages the practice of "commit early and often". CI runs on GitHub for free and is required before anything can be merged anyway, so I don't see many advantages of enforcing CI before every push.

>Describe the solution you'd like
We could be running npx lint-staged at a minimum so we are still pushing lint-safe code while keeping our wait time down to just seconds instead of minutes. Other errors will happen within GitHub CI and that feels totally fine for me.

